### PR TITLE
group: add metadata_json field for complex metadata

### DIFF
--- a/matchbox/resource_group_test.go
+++ b/matchbox/resource_group_test.go
@@ -64,3 +64,57 @@ func TestResourceGroup(t *testing.T) {
 	})
 
 }
+
+func TestResourceGroupJSON(t *testing.T) {
+	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
+	go srv.Start()
+	defer srv.Stop()
+
+	hcl := `
+		resource "matchbox_group" "default" {
+ 			name    = "default"
+  			profile = "foo"
+  			selector {
+				  qux = "baz"
+			}
+
+			metadata_json = "{\"foo\":\"bar\"}"
+		}
+	`
+
+	check := func(s *terraform.State) error {
+		grp, err := srv.Store.GroupGet("default")
+		if err != nil {
+			return err
+		}
+
+		if grp.GetId() != "default" {
+			return fmt.Errorf("id, found %q", grp.GetId())
+		}
+
+		if grp.GetProfile() != "foo" {
+			return fmt.Errorf("profile, found %q", grp.GetProfile())
+		}
+
+		selector := grp.GetSelector()
+		if len(selector) != 1 || selector["qux"] != "baz" {
+			return fmt.Errorf("selector.qux, found %q", selector["qux"])
+		}
+
+		if string(grp.GetMetadata()) != "{\"foo\":\"bar\"}" {
+			return fmt.Errorf("metadata, found %q", grp.GetProfile())
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  providers,
+		Steps: []resource.TestStep{{
+			Config: srv.AddProviderConfig(hcl),
+			Check:  check,
+		}},
+	})
+
+}


### PR DESCRIPTION
this adds a metadata_json field to the matchbox_group resource
so complex metadata (including arrays and objects) can be passed
to matchbox.