### PR TITLE
Update Go versions in .travis.yml tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: go
 go:
-  - "1.10.x"
-  - "1.11.x"
   - "1.12.x"
+  - "1.13.x"
+  - "1.14.x"
 install:
-  - go get golang.org/x/lint/golint
+  - GO111MODULE=off go get golang.org/x/lint/golint
 script:
   - make
 notifications:


### PR DESCRIPTION
* Test plugin with Go v1.12, v1.13, and v1.14