### PR TITLE
Favor Terraform v0.13 usage in README and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ Configure the Matchbox provider with the Matchbox API endpoint and client certif
 
 ```tf
 provider "matchbox" {
-  version = "0.4.0"
   endpoint    = "matchbox.example.com:8081"
   client_cert = "${file("~/.matchbox/client.crt")}"
   client_key  = "${file("~/.matchbox/client.key")}"
   ca          = "${file("~/.matchbox/ca.crt")}"
+}
+
+terraform {
+  required_providers {
+    matchbox = {
+      source = "poseidon/matchbox"
+      version = "0.4.1"
+    }
+  }
 }
 ```
 
@@ -63,30 +71,9 @@ See [examples](https://github.com/poseidon/matchbox/tree/master/examples/terrafo
 
 ## Requirements
 
-* Terraform v0.11+ [installed](https://www.terraform.io/downloads.html)
+* Terraform v0.12+ [installed](https://www.terraform.io/downloads.html)
 * Matchbox v0.8+ [installed](https://matchbox.psdn.io/deployment/)
 * Matchbox credentials `client.crt`, `client.key`, `ca.crt`
-
-## Install
-
-Add the `terraform-provider-matchbox` plugin binary for your system to the Terraform 3rd-party [plugin directory](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) `~/.terraform.d/plugins`.
-
-```sh
-VERSION=v0.4.0
-wget https://github.com/poseidon/terraform-provider-matchbox/releases/download/$VERSION/terraform-provider-matchbox-$VERSION-linux-amd64.tar.gz
-tar xzf terraform-provider-matchbox-$VERSION-linux-amd64.tar.gz
-mv terraform-provider-matchbox-$VERSION-linux-amd64/terraform-provider-matchbox ~/.terraform.d/plugins/terraform-provider-matchbox_$VERSION
-```
-
-Terraform plugin binary names are versioned to allow for migrations of managed infrastructure.
-
-```
-$ tree ~/.terraform.d/
-/home/user/.terraform.d/
-└── plugins
-    ├── terraform-provider-matchbox_v0.3.0
-    └── terraform-provider-matchbox_v0.4.0
-```
 
 ## Development
 
@@ -105,5 +92,26 @@ Add or update dependencies in `go.mod` and vendor.
 ```
 make update
 make vendor
+```
+
+## Legacy Install
+
+For Terraform v0.12, add the `terraform-provider-matchbox` plugin binary for your system to the Terraform 3rd-party [plugin directory](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) `~/.terraform.d/plugins`.
+
+```sh
+VERSION=v0.4.0
+wget https://github.com/poseidon/terraform-provider-matchbox/releases/download/$VERSION/terraform-provider-matchbox-$VERSION-linux-amd64.tar.gz
+tar xzf terraform-provider-matchbox-$VERSION-linux-amd64.tar.gz
+mv terraform-provider-matchbox-$VERSION-linux-amd64/terraform-provider-matchbox ~/.terraform.d/plugins/terraform-provider-matchbox_$VERSION
+```
+
+Terraform plugin binary names are versioned to allow for migrations of managed infrastructure.
+
+```
+$ tree ~/.terraform.d/
+/home/user/.terraform.d/
+└── plugins
+    ├── terraform-provider-matchbox_v0.3.0
+    └── terraform-provider-matchbox_v0.4.0
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,19 @@ Configure the Matchbox provider with the Matchbox API endpoint and client certif
 
 ```tf
 provider "matchbox" {
-  version = "0.4.0"
   endpoint    = "matchbox.example.com:8081"
   client_cert = "${file("~/.matchbox/client.crt")}"
   client_key  = "${file("~/.matchbox/client.key")}"
   ca          = "${file("~/.matchbox/ca.crt")}"
+}
+
+terraform {
+  required_providers {
+    matchbox = {
+      source = "poseidon/matchbox"
+      version = "0.4.1"
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
* Show usage of matchbox provider from the Terraform Registry
* Move 3rd-party plugin install to legacy install (for Terraform v0.12)