### PR TITLE
Update Go version and cleanup docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,14 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.14', '1.15', '1.16']
+        go: ['1.16', '1.17']
     steps:
-      - name: setup
+      - name: setup Go
         uses: actions/setup-go@v2
         with:
           go-version: ${{matrix.go}}
 
-      - uses: hashicorp/setup-terraform@v1
+      - name: setup Terraform
+        uses: hashicorp/setup-terraform@v1
         with:
           terraform_wrapper: false
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Notable changes between releases.
 ## Latest
 
 * Migrate Terraform Plugin SDK from v1.9.0 to v2.3.0 ([#56](https://github.com/poseidon/terraform-provider-matchbox/pull/56))
+* Remove Go module vendoring
+* Remove tarball release format
 
 ## v0.4.1
 

--- a/Makefile
+++ b/Makefile
@@ -36,21 +36,10 @@ clean:
 .PHONY: release
 release: \
 	clean \
-	_output/plugin-linux-amd64.tar.gz \
-	_output/plugin-linux-arm64.tar.gz \
-	_output/plugin-darwin-amd64.tar.gz \
-	_output/plugin-windows-amd64.tar.gz \
 	_output/plugin-linux-amd64.zip \
 	_output/plugin-linux-arm64.zip \
 	_output/plugin-darwin-amd64.zip \
 	_output/plugin-windows-amd64.zip
-
-_output/plugin-%.tar.gz: NAME=terraform-provider-matchbox-$(VERSION)-$*
-_output/plugin-%.tar.gz: DEST=_output/$(NAME)
-_output/plugin-%.tar.gz: _output/%/terraform-provider-matchbox
-	@mkdir -p $(DEST)
-	@cp _output/$*/terraform-provider-matchbox $(DEST)
-	@tar zcvf $(DEST).tar.gz -C _output $(NAME)
 
 _output/plugin-%.zip: NAME=terraform-provider-matchbox_$(SEMVER)_$(subst -,_,$*)
 _output/plugin-%.zip: DEST=_output/$(NAME)
@@ -68,18 +57,10 @@ _output/%/terraform-provider-matchbox:
 
 release-sign:
 	cd _output; sha256sum *.zip > terraform-provider-matchbox_$(SEMVER)_SHA256SUMS
-	gpg2 --armor --detach-sign _output/terraform-provider-matchbox-$(VERSION)-linux-amd64.tar.gz
-	gpg2 --armor --detach-sign _output/terraform-provider-matchbox-$(VERSION)-linux-arm64.tar.gz
-	gpg2 --armor --detach-sign _output/terraform-provider-matchbox-$(VERSION)-darwin-amd64.tar.gz
-	gpg2 --armor --detach-sign _output/terraform-provider-matchbox-$(VERSION)-windows-amd64.tar.gz
 	gpg2 --detach-sign _output/terraform-provider-matchbox_$(SEMVER)_SHA256SUMS
 
 release-verify: NAME=_output/terraform-provider-matchbox
 release-verify:
-	gpg2 --verify $(NAME)-$(VERSION)-linux-amd64.tar.gz.asc $(NAME)-$(VERSION)-linux-amd64.tar.gz
-	gpg2 --verify $(NAME)-$(VERSION)-linux-arm64.tar.gz.asc $(NAME)-$(VERSION)-linux-arm64.tar.gz
-	gpg2 --verify $(NAME)-$(VERSION)-darwin-amd64.tar.gz.asc $(NAME)-$(VERSION)-darwin-amd64.tar.gz
-	gpg2 --verify $(NAME)-$(VERSION)-windows-amd64.tar.gz.asc $(NAME)-$(VERSION)-windows-amd64.tar.gz
 	gpg2 --verify $(NAME)_$(SEMVER)_SHA256SUMS.sig $(NAME)_$(SEMVER)_SHA256SUMS
 
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See [examples](https://github.com/poseidon/matchbox/tree/master/examples/terrafo
 
 ## Requirements
 
-* Terraform v0.12+ [installed](https://www.terraform.io/downloads.html)
+* Terraform v0.13+ [installed](https://www.terraform.io/downloads.html)
 * Matchbox v0.8+ [installed](https://matchbox.psdn.io/deployment/)
 * Matchbox credentials `client.crt`, `client.key`, `ca.crt`
 
@@ -79,39 +79,8 @@ See [examples](https://github.com/poseidon/matchbox/tree/master/examples/terrafo
 
 ### Binary
 
-To develop the provider plugin locally, build an executable with Go 1.12+.
+To develop the provider plugin locally, build an executable with Go 1.16+.
 
 ```
 make
 ```
-
-### Vendor
-
-Add or update dependencies in `go.mod` and vendor.
-
-```
-make update
-make vendor
-```
-
-## Legacy Install
-
-For Terraform v0.12, add the `terraform-provider-matchbox` plugin binary for your system to the Terraform 3rd-party [plugin directory](https://www.terraform.io/docs/configuration/providers.html#third-party-plugins) `~/.terraform.d/plugins`.
-
-```sh
-VERSION=v0.4.0
-wget https://github.com/poseidon/terraform-provider-matchbox/releases/download/$VERSION/terraform-provider-matchbox-$VERSION-linux-amd64.tar.gz
-tar xzf terraform-provider-matchbox-$VERSION-linux-amd64.tar.gz
-mv terraform-provider-matchbox-$VERSION-linux-amd64/terraform-provider-matchbox ~/.terraform.d/plugins/terraform-provider-matchbox_$VERSION
-```
-
-Terraform plugin binary names are versioned to allow for migrations of managed infrastructure.
-
-```
-$ tree ~/.terraform.d/
-/home/user/.terraform.d/
-└── plugins
-    ├── terraform-provider-matchbox_v0.3.0
-    └── terraform-provider-matchbox_v0.4.0
-```
-

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,4 @@ require (
 	google.golang.org/grpc v1.40.0
 )
 
-go 1.13
+go 1.16


### PR DESCRIPTION
* Update minimum Go version to v1.16 for future arm64
* Update minimum Terraform version
* Remove mention of Go module versioning and legacy Terraform instructions
* Remove old tarball release format