### PR TITLE
Fix golangci-lint warnings and update tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,8 +23,5 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: tools
-        run: go install golang.org/x/lint/golint@latest
-
       - name: test
         run: make

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION=$(shell git describe --tags --match=v* --always --dirty)
 SEMVER=$(shell git describe --tags --match=v* --always --dirty | cut -c 2-)
 
 .PHONY: all
-all: build test vet lint fmt
+all: build test vet fmt
 
 .PHONY: build
 build: clean bin/terraform-provider-matchbox
@@ -19,10 +19,6 @@ test:
 .PHONY: vet
 vet:
 	@go vet -all ./...
-
-.PHONY: lint
-lint:
-	@golint -set_exit_status `go list ./...`
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ See [examples](https://github.com/poseidon/matchbox/tree/master/examples/terrafo
 
 ### Binary
 
-To develop the provider plugin locally, build an executable with Go 1.16+.
+To develop the provider plugin locally, build an executable with Go 1.17+.
 
 ```
 make

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,53 @@ require (
 	google.golang.org/grpc v1.48.0
 )
 
-go 1.16
+require (
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.13.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-plugin v1.4.4 // indirect
+	github.com/hashicorp/go-uuid v1.0.3 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
+	github.com/hashicorp/hc-install v0.4.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.13.0 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform-exec v0.17.2 // indirect
+	github.com/hashicorp/terraform-json v0.14.0 // indirect
+	github.com/hashicorp/terraform-plugin-go v0.12.0 // indirect
+	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect
+	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c // indirect
+	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.4.2 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
+	github.com/vmihailenco/tagparser v0.1.1 // indirect
+	github.com/zclconf/go-cty v1.10.0 // indirect
+	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
+)
+
+go 1.17

--- a/matchbox/fixture_test.go
+++ b/matchbox/fixture_test.go
@@ -60,15 +60,15 @@ func NewFixtureServer(clientTLS *TLSContents, serverTLS *tlsutil.TLSInfo, s stor
 	}
 }
 
-func (s *FixtureServer) Start() {
+func (s *FixtureServer) Start() error {
 	cfg, err := s.ServerTLS.ServerConfig()
 	if err != nil {
-		panic(fmt.Errorf("Invalid TLS credentials: %v", err))
+		return fmt.Errorf("Invalid TLS credentials: %v", err)
 	}
 
 	srv := server.NewServer(&server.Config{Store: s.Store})
 	s.Server = rpc.NewServer(srv, cfg)
-	s.Server.Serve(s.Listener)
+	return s.Server.Serve(s.Listener)
 }
 
 func (s *FixtureServer) Stop() {

--- a/matchbox/provider.go
+++ b/matchbox/provider.go
@@ -10,19 +10,19 @@ import (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"endpoint": &schema.Schema{
+			"endpoint": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"client_cert": &schema.Schema{
+			"client_cert": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"client_key": &schema.Schema{
+			"client_key": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"ca": &schema.Schema{
+			"ca": {
 				Type:     schema.TypeString,
 				Required: true,
 			},

--- a/matchbox/resource_group.go
+++ b/matchbox/resource_group.go
@@ -19,23 +19,23 @@ func resourceGroup() *schema.Resource {
 		DeleteContext: resourceGroupDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"profile": &schema.Schema{
+			"profile": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"selector": &schema.Schema{
+			"selector": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem:     schema.TypeString,
 				ForceNew: true,
 			},
-			"metadata": &schema.Schema{
+			"metadata": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem:     schema.TypeString,

--- a/matchbox/resource_group_test.go
+++ b/matchbox/resource_group_test.go
@@ -11,7 +11,12 @@ import (
 
 func TestResourceGroup(t *testing.T) {
 	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
-	go srv.Start()
+	go func() {
+		err := srv.Start()
+		if err != nil {
+			t.Errorf("fixture server start: %v", err)
+		}
+	}()
 	defer srv.Stop()
 
 	hcl := `
@@ -67,7 +72,12 @@ func TestResourceGroup(t *testing.T) {
 // the Terraform state.
 func TestResourceGroup_Read(t *testing.T) {
 	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
-	go srv.Start()
+	go func() {
+		err := srv.Start()
+		if err != nil {
+			t.Errorf("fixture server start: %v", err)
+		}
+	}()
 	defer srv.Stop()
 
 	hcl := `

--- a/matchbox/resource_profile.go
+++ b/matchbox/resource_profile.go
@@ -21,17 +21,17 @@ func resourceProfile() *schema.Resource {
 		DeleteContext: resourceProfileDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"kernel": &schema.Schema{
+			"kernel": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"initrd": &schema.Schema{
+			"initrd": {
 				Type: schema.TypeList,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -39,7 +39,7 @@ func resourceProfile() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"args": &schema.Schema{
+			"args": {
 				Type: schema.TypeList,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -47,17 +47,17 @@ func resourceProfile() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"container_linux_config": &schema.Schema{
+			"container_linux_config": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"raw_ignition": &schema.Schema{
+			"raw_ignition": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"generic_config": &schema.Schema{
+			"generic_config": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,

--- a/matchbox/resource_profile_test.go
+++ b/matchbox/resource_profile_test.go
@@ -12,7 +12,12 @@ import (
 
 func TestResourceProfile(t *testing.T) {
 	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
-	go srv.Start()
+	go func() {
+		err := srv.Start()
+		if err != nil {
+			t.Errorf("fixture server start: %v", err)
+		}
+	}()
 	defer srv.Stop()
 
 	hcl := `
@@ -93,7 +98,12 @@ func TestResourceProfile(t *testing.T) {
 
 func TestResourceProfile_withIgnition(t *testing.T) {
 	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
-	go srv.Start()
+	go func() {
+		err := srv.Start()
+		if err != nil {
+			t.Errorf("fixture server start: %v", err)
+		}
+	}()
 	defer srv.Stop()
 
 	hcl := `
@@ -146,7 +156,12 @@ func TestResourceProfile_withIgnition(t *testing.T) {
 
 func TestResourceProfile_withIgnitionAndContainerLinuxConfig(t *testing.T) {
 	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
-	go srv.Start()
+	go func() {
+		err := srv.Start()
+		if err != nil {
+			t.Errorf("fixture server start: %v", err)
+		}
+	}()
 	defer srv.Stop()
 
 	hcl := `
@@ -170,7 +185,12 @@ func TestResourceProfile_withIgnitionAndContainerLinuxConfig(t *testing.T) {
 // the Terraform state.
 func TestResourceProfile_Read(t *testing.T) {
 	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
-	go srv.Start()
+	go func() {
+		err := srv.Start()
+		if err != nil {
+			t.Errorf("fixture server start: %v", err)
+		}
+	}()
 	defer srv.Stop()
 
 	hcl := `


### PR DESCRIPTION
* Update minimum expected Go version to v1.17
* Remove deprecated golint tooling