### PR TITLE
Fix regession in matchbox_group reading of empty metadata

### DIFF
--- a/matchbox/resource_group.go
+++ b/matchbox/resource_group.go
@@ -95,15 +95,18 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	group := groupGetResponse.Group
 
-	var metadata map[string]string
-	if err := json.Unmarshal(group.Metadata, &metadata); err != nil {
-		return diag.FromErr(err)
-	}
 	if err := d.Set("selector", group.Selector); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set("profile", group.Profile); err != nil {
 		return diag.FromErr(err)
+	}
+
+	var metadata map[string]string
+	if len(group.Metadata) > 0 {
+		if err := json.Unmarshal(group.Metadata, &metadata); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	if err := d.Set("metadata", metadata); err != nil {
 		return diag.FromErr(err)

--- a/matchbox/resource_profile_test.go
+++ b/matchbox/resource_profile_test.go
@@ -181,8 +181,8 @@ func TestResourceProfile_withIgnitionAndContainerLinuxConfig(t *testing.T) {
 	})
 }
 
-// TestResourceProfile_Read checks the provider compares the desired state with the actual matchbox state and not only
-// the Terraform state.
+// TestResourceProfile_Read checks the provider compares the desired state with
+// the actual matchbox state
 func TestResourceProfile_Read(t *testing.T) {
 	srv := NewFixtureServer(clientTLSInfo, serverTLSInfo, testfakes.NewFixedStore())
 	go func() {


### PR DESCRIPTION
* Fix "unexpected end of JSON input" error when planning or applying after a matchbox_group without metadata is created (a common case)
* Group metadata is returned as an empty []byte, so its not valid to try to parse it as JSON
* Add test coverage and improve testing in general

Regressed by https://github.com/poseidon/terraform-provider-matchbox/pull/68