### PR TITLE
Replace UnitTest Providers with ProviderFactories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/poseidon/terraform-provider-matchbox
 go 1.18
 
 require (
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0
 	github.com/poseidon/matchbox v0.9.1
 	google.golang.org/grpc v1.49.0
 )
@@ -14,7 +14,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,9 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -135,8 +136,8 @@ github.com/hashicorp/terraform-plugin-go v0.14.0 h1:ttnSlS8bz3ZPYbMb84DpcPhY4F5D
 github.com/hashicorp/terraform-plugin-go v0.14.0/go.mod h1:2nNCBeRLaenyQEi78xrGrs9hMbulveqG/zDMQSvVJTE=
 github.com/hashicorp/terraform-plugin-log v0.7.0 h1:SDxJUyT8TwN4l5b5/VkiTIaQgY6R+Y2BQ0sRZftGKQs=
 github.com/hashicorp/terraform-plugin-log v0.7.0/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0 h1:MzfNfrheTt24xbEbA4npUSbX3GYu4xjXS7czcpJFyQY=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0/go.mod h1:q1XKSxXg9nDmhV0IvNZNZxe3gcTAHzMqrjs8wX1acng=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0 h1:D4EeQm0piYXIHp6ZH3zjyP2Elq6voC64x3GZptaiefA=
+github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0/go.mod h1:xkJGavPvP9kYS/VbiW8o7JuTNgPwm7Tiw/Ie/b46r4c=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/matchbox/fixture_test.go
+++ b/matchbox/fixture_test.go
@@ -2,8 +2,8 @@ package matchbox
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 
 	"github.com/poseidon/matchbox/matchbox/rpc"
 	"github.com/poseidon/matchbox/matchbox/server"
@@ -104,7 +104,7 @@ CA
 
 // mustFile wraps a call to ioutil.ReadFile and panics if the error is non-nil.
 func mustReadFile(filename string) []byte {
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}

--- a/matchbox/provider_test.go
+++ b/matchbox/provider_test.go
@@ -6,8 +6,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var testProviders = map[string]*schema.Provider{
-	"matchbox": Provider(),
+var testProviderFactories = map[string]func() (*schema.Provider, error){
+	"matchbox": func() (*schema.Provider, error) {
+		return Provider(), nil
+	},
 }
 
 func TestProvider(t *testing.T) {

--- a/matchbox/resource_group_test.go
+++ b/matchbox/resource_group_test.go
@@ -42,7 +42,7 @@ func TestResourceGroup(t *testing.T) {
 	defer srv.Stop()
 
 	resource.UnitTest(t, resource.TestCase{
-		Providers: testProviders,
+		ProviderFactories: testProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: srv.AddProviderConfig(groupWithAllFields),
@@ -92,7 +92,7 @@ func TestResourceGroup_Read(t *testing.T) {
 	defer srv.Stop()
 
 	resource.UnitTest(t, resource.TestCase{
-		Providers: testProviders,
+		ProviderFactories: testProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: srv.AddProviderConfig(groupWithAllFields),

--- a/matchbox/resource_profile_test.go
+++ b/matchbox/resource_profile_test.go
@@ -87,7 +87,7 @@ func TestResourceProfile(t *testing.T) {
 	}
 
 	resource.UnitTest(t, resource.TestCase{
-		Providers: testProviders,
+		ProviderFactories: testProviderFactories,
 		Steps: []resource.TestStep{{
 			Config: srv.AddProviderConfig(hcl),
 			Check:  check,
@@ -145,7 +145,7 @@ func TestResourceProfile_withIgnition(t *testing.T) {
 	}
 
 	resource.UnitTest(t, resource.TestCase{
-		Providers: testProviders,
+		ProviderFactories: testProviderFactories,
 		Steps: []resource.TestStep{{
 			Config: srv.AddProviderConfig(hcl),
 			Check:  check,
@@ -173,7 +173,7 @@ func TestResourceProfile_withIgnitionAndContainerLinuxConfig(t *testing.T) {
 	`
 
 	resource.UnitTest(t, resource.TestCase{
-		Providers: testProviders,
+		ProviderFactories: testProviderFactories,
 		Steps: []resource.TestStep{{
 			Config:      srv.AddProviderConfig(hcl),
 			ExpectError: regexp.MustCompile("are mutually exclusive"),
@@ -211,7 +211,7 @@ func TestResourceProfile_Read(t *testing.T) {
 	`
 
 	resource.UnitTest(t, resource.TestCase{
-		Providers: testProviders,
+		ProviderFactories: testProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: srv.AddProviderConfig(hcl),


### PR DESCRIPTION
* UnitTest `Providers` was deprecated in favor of `ProviderFactories`
* Workaround an issue with the terraform-plugin-sdk v2.23.0 that causes duplicate provider blocks when UnitTest.Providers is used
* Update terraform-plugin-sdk from v2.22.0 to v2.23.0

Rel: https://github.com/hashicorp/terraform-plugin-sdk/issues/1064