### PR TITLE
Fix the release signing process to use RSA

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,15 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.5.4
+
+* Fix release signing process to use a compatible OpenPGP key algorithm
+  * Terraform Registry does not support ed25519, sign with the RSA key like in past releases
+
 ## v0.5.3
 
 * Maintenance update to bump dependencies
+* Skip this release, it was signed with the wrong key
 
 ## v0.5.2
 

--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,11 @@ _output/%/terraform-provider-matchbox:
 
 release-sign:
 	cd _output; sha256sum *.zip > terraform-provider-matchbox_$(SEMVER)_SHA256SUMS
-	gpg2 --detach-sign _output/terraform-provider-matchbox_$(SEMVER)_SHA256SUMS
+	gpg --default-key 0x8F515AD1602065C8 --detach-sign _output/terraform-provider-matchbox_$(SEMVER)_SHA256SUMS
 
 release-verify: NAME=_output/terraform-provider-matchbox
 release-verify:
-	gpg2 --verify $(NAME)_$(SEMVER)_SHA256SUMS.sig $(NAME)_$(SEMVER)_SHA256SUMS
-
+	gpg --verify $(NAME)_$(SEMVER)_SHA256SUMS.sig $(NAME)_$(SEMVER)_SHA256SUMS
 
 .PHONY: certificates
 certificates:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     matchbox = {
       source = "poseidon/matchbox"
-      version = "0.5.2"
+      version = "0.5.4"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     matchbox = {
       source = "poseidon/matchbox"
-      version = "0.5.2"
+      version = "0.5.4"
     }
   }
 }


### PR DESCRIPTION
* Terraform Registry does not yet support ed25519 so revert to using the older RSA key that has been used to sign prior releases